### PR TITLE
Fixed setup of ERC4626 properties

### DIFF
--- a/test/mocks/USDC.t.sol
+++ b/test/mocks/USDC.t.sol
@@ -21,4 +21,8 @@ contract USDC is ERC20, IERC20MintBurn, Ownable {
     function burn(address account, uint256 amount) external onlyOwner {
         _burn(account, amount);
     }
+
+    function forceApproval(address owner, address spender, uint256 value) external onlyOwner {
+        _approve(owner, spender, value);
+    }
 }

--- a/test/property/crytic/AaveStrategyVaultCryticERC4626Harness.t.sol
+++ b/test/property/crytic/AaveStrategyVaultCryticERC4626Harness.t.sol
@@ -7,6 +7,7 @@ import {Setup} from "@test/Setup.t.sol";
 contract AaveStrategyVaultCryticERC4626Harness is CryticERC4626PropertyTests, Setup {
     constructor() {
         deploy(address(this));
-        initialize(address(cryticAaveStrategyVault), address(asset), true);
+        require(address(erc20Asset) != address(0));
+        initialize(address(cryticAaveStrategyVault), address(erc20Asset), true);
     }
 }

--- a/test/property/crytic/CashStrategyVaultCryticERC4626Harness.t.sol
+++ b/test/property/crytic/CashStrategyVaultCryticERC4626Harness.t.sol
@@ -7,6 +7,7 @@ import {Setup} from "@test/Setup.t.sol";
 contract CashStrategyVaultCryticERC4626Harness is CryticERC4626PropertyTests, Setup {
     constructor() {
         deploy(address(this));
-        initialize(address(cryticCashStrategyVault), address(asset), true);
+        require(address(erc20Asset) != address(0));
+        initialize(address(cryticCashStrategyVault), address(erc20Asset), true);
     }
 }

--- a/test/property/crytic/ERC4626StrategyVaultCryticERC4626Harness.t.sol
+++ b/test/property/crytic/ERC4626StrategyVaultCryticERC4626Harness.t.sol
@@ -7,6 +7,7 @@ import {Setup} from "@test/Setup.t.sol";
 contract ERC4626StrategyVaultCryticERC4626Harness is CryticERC4626PropertyTests, Setup {
     constructor() {
         deploy(address(this));
-        initialize(address(cryticERC4626StrategyVault), address(asset), true);
+        require(address(erc20Asset) != address(0));
+        initialize(address(cryticERC4626StrategyVault), address(erc20Asset), true);
     }
 }

--- a/test/property/crytic/VeryLiquidVaultCryticERC4626Harness.t.sol
+++ b/test/property/crytic/VeryLiquidVaultCryticERC4626Harness.t.sol
@@ -10,7 +10,8 @@ import {Setup} from "@test/Setup.t.sol";
 contract VeryLiquidVaultCryticERC4626Harness is CryticERC4626PropertyTests, Setup {
     constructor() {
         deploy(address(this));
-        initialize(address(veryLiquidVault), address(asset), true);
+        require(address(erc20Asset) != address(0));
+        initialize(address(veryLiquidVault), address(erc20Asset), true);
         _setupRandomVeryLiquidVaultConfiguration(address(this), _getRandomUint2);
     }
 


### PR DESCRIPTION
The original ERC4626 properties fuzzing campaign had some issues that blocked them to properly test all the code. This PR contains two fixes:

* Proper initialization: `asset` is 0x0. The actual address that needs to be used is `erc20Asset`.
* Additional function needed in the mock asset. The properties assume that the `forceApproval` is available to setup the allowances without using cheatcodes.